### PR TITLE
Fix multiple apn items issue

### DIFF
--- a/src/com/android/phone/CdmaOptions.java
+++ b/src/com/android/phone/CdmaOptions.java
@@ -69,7 +69,8 @@ public class CdmaOptions {
         PersistableBundle carrierConfig =
                 PhoneGlobals.getInstance().getCarrierConfigForSubId(mPhone.getSubId());
         // Some CDMA carriers want the APN settings.
-        if (!carrierConfig.getBoolean(CarrierConfigManager.KEY_SHOW_APN_SETTING_CDMA_BOOL)
+        if ((!carrierConfig.getBoolean(CarrierConfigManager.KEY_SHOW_APN_SETTING_CDMA_BOOL)
+                || carrierConfig.getBoolean(CarrierConfigManager.KEY_WORLD_PHONE_BOOL))
                 && mButtonAPNExpand != null) {
             mPrefScreen.removePreference(mButtonAPNExpand);
             removedAPNExpand = true;


### PR DESCRIPTION
Apn item is created twice, from GsmUmtsOptions and CdmaOptions.
Add world_phone config check to remove apn preference created
from CdmaOptions.

Change-Id: I702490969618d8f817dd639326f3643d2fefee4e
CRs-Fixed: 886690